### PR TITLE
Fix attempt to index field 'db' (a nil value) in Auras.lua

### DIFF
--- a/Modules/Unitframes/Auras.lua
+++ b/Modules/Unitframes/Auras.lua
@@ -1242,7 +1242,7 @@ function mod:Toggle(db)
 										for _, frame in ipairs(core:AggregateUnitFrames()) do
 											for _, auraType in ipairs({'Buffs', 'Debuffs'}) do
 												local element = frame[auraType]
-												if element and element.db.enable and element.ForceUpdate then
+												if element and element.db and element.db.enable and element.ForceUpdate then
 													element:ForceUpdate()
 												end
 											end


### PR DESCRIPTION
This fixes an issue where moving filters by drag and drop throws a nil error when the unit frame aura element has not initialized its `.db` yet.

this was the error
```
Message: ...ace\AddOns\ElvUI_Extras\Modules\Unitframes\Auras.lua:1245: attempt to index field 'db' (a nil value)
Time: 05/24/26 15:12:10
Count: 2
Stack: [C]: ?
...ace\AddOns\ElvUI_Extras\Modules\Unitframes\Auras.lua:1245: in function <...ace\AddOns\ElvUI_Extras\Modules\Unitframes\Auras.lua:1240>
(tail call): ?
[C]: ?
[string "safecall Dispatcher[2]"]:3: in function <[string "safecall Dispatcher[2]"]:3>
[C]: ?
[string "safecall Dispatcher[2]"]:9: in function <[string "safecall Dispatcher[2]"]:5>
(tail call): ?
...nfig-3.0\AceConfigDialog-3.0\AceConfigDialog-3.0.lua:848: in function <...nfig-3.0\AceConfigDialog-3.0\AceConfigDialog-3.0.lua:669>
(tail call): ?
[C]: ?
[string "safecall Dispatcher[3]"]:9: in function <[string "safecall Dispatcher[3]"]:5>
(tail call): ?
...I_OptionsUI\Libraries\Ace3\AceGUI-3.0\AceGUI-3.0.lua:334: in function `Fire'
...es\Ace3\AceGUI-3.0\widgets\AceGUIWidget-DropDown.lua:442: in function <...es\Ace3\AceGUI-3.0\widgets\AceGUIWidget-DropDown.lua:433>
(tail call): ?
[C]: ?
[string "safecall Dispatcher[3]"]:9: in function <[string "safecall Dispatcher[3]"]:5>
(tail call): ?
...I_OptionsUI\Libraries\Ace3\AceGUI-3.0\AceGUI-3.0.lua:334: in function `Fire'
...s\AceGUI-3.0\widgets\AceGUIWidget-DropDown-Items.lua:351: in function <...s\AceGUI-3.0\widgets\AceGUIWidget-DropDown-Items.lua:341>

Locals: